### PR TITLE
Revert "bring npm API in line with global and amd API"

### DIFF
--- a/src/js/alertify.js
+++ b/src/js/alertify.js
@@ -498,7 +498,7 @@
 
     // AMD, window, and NPM support
     if ("undefined" !== typeof module && !! module && !! module.exports) {
-        module.exports = new Alertify();
+        module.exports = Alertify;
     } else if (typeof define === "function" && define.amd) {
         define(function() {
             return new Alertify();

--- a/src/js/ngAlertify.js
+++ b/src/js/ngAlertify.js
@@ -9,7 +9,7 @@ angular.module("ngAlertify", []).factory("alertify", function() {
     // automatically injected here based on the string contents.
     /* alertify.js */
 
-    var alertify = module.exports;
-    return alertify;
+    var Alertify = module.exports;
+    return new Alertify();
 
 });


### PR DESCRIPTION
This reverts commit 944ba40bf45d9e070b4c35d37de3a9b21a8512f2.

It is a MAJOR api change. Let's revert this, publish a new patch version and then discuss if we want to do this in its own issue.