### PR TITLE
commonjs: create default instance

### DIFF
--- a/karma-ci.conf.js
+++ b/karma-ci.conf.js
@@ -45,7 +45,7 @@ module.exports = function(config) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ["jasmine"],
+        frameworks: ["browserify", "jasmine"],
 
         // list of files / patterns to load in the browser
         files: [
@@ -68,6 +68,16 @@ module.exports = function(config) {
         // possible values: "dots", "progress"
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
         reporters: ['dots', 'saucelabs'],
+
+        // Browserify bundle
+        browserify: {
+            debug: true,
+            configure: function(bundle) {
+                bundle.on('prebundle', function() {
+                    bundle.require('./src/js/alertify.js', { expose: 'alertify' });
+                });
+            }
+        },
 
         // web server port
         port: 9876,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ["jasmine"],
+        frameworks: ["browserify", "jasmine"],
 
         // list of files / patterns to load in the browser
         files: [
@@ -30,6 +30,16 @@ module.exports = function(config) {
         },
 
         reporters: ["dots", "coverage", "coveralls"],
+
+        // Browserify bundle
+        browserify: {
+            debug: true,
+            configure: function(bundle) {
+                bundle.on('prebundle', function() {
+                    bundle.require('./src/js/alertify.js', { expose: 'alertify' });
+                });
+            }
+        },
 
         autoWatch: true,
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gulp-uglify": "^1.2.0",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.10",
+    "karma-browserify": "^4.4.2",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.2",
     "karma-coveralls": "^1.1.2",

--- a/src/js/alertify.js
+++ b/src/js/alertify.js
@@ -498,7 +498,14 @@
 
     // AMD, window, and NPM support
     if ("undefined" !== typeof module && !! module && !! module.exports) {
-        module.exports = Alertify;
+        // Preserve backwards compatibility
+        module.exports = function() {
+            return new Alertify();
+        };
+        var obj = new Alertify();
+        for (var key in obj) {
+            module.exports[key] = obj[key];
+        }
     } else if (typeof define === "function" && define.amd) {
         define(function() {
             return new Alertify();

--- a/test/commonjsSpec.js
+++ b/test/commonjsSpec.js
@@ -1,0 +1,39 @@
+/* eslint-env karma, jasmine */
+/* eslint strict: [2, "global"] */
+/* global require */
+"use strict";
+
+describe("commonjs test suite", function() {
+
+    var Alertify = require('alertify');
+
+    it("should be a function", function() {
+        expect(typeof Alertify).toBe("function");
+    });
+
+    [ Alertify, new Alertify(), Alertify() ].forEach(function(alertify) {
+        it("should define the public methods", function() {
+            expect(typeof alertify.reset).toBe("function");
+            expect(typeof alertify.alert).toBe("function");
+            expect(typeof alertify.confirm).toBe("function");
+            expect(typeof alertify.prompt).toBe("function");
+            expect(typeof alertify.log).toBe("function");
+            expect(typeof alertify.success).toBe("function");
+            expect(typeof alertify.error).toBe("function");
+            expect(typeof alertify.cancelBtn).toBe("function");
+            expect(typeof alertify.okBtn).toBe("function");
+            expect(typeof alertify.delay).toBe("function");
+            expect(typeof alertify.placeholder).toBe("function");
+            expect(typeof alertify.defaultValue).toBe("function");
+            expect(typeof alertify.maxLogItems).toBe("function");
+            expect(typeof alertify.closeLogOnClick).toBe("function");
+        });
+    });
+
+    it("should be different instances", function() {
+        var alertify = new Alertify();
+        alertify.defaultValue('foo');
+        expect(alertify._$$alertify).not.toEqual(Alertify._$$alertify);
+    });
+
+});


### PR DESCRIPTION
This brings the commonjs api in line with the global and amd api while
preserving backwards compatibility.

Related to https://github.com/alertifyjs/alertify.js/pull/63