### PR TITLE
Use standar event.target

### DIFF
--- a/src/js/alertify.js
+++ b/src/js/alertify.js
@@ -115,7 +115,7 @@
 
                 if (this.closeLogOnClick) {
                     elem.addEventListener("click", function(ev) {
-                        hideElement(ev.srcElement);
+                        hideElement(ev.target);
                     });
                 }
 


### PR DESCRIPTION
event.srcElement isn't standard, so it doesn't work in modern browsers.

The standar is event.target:

https://developer.mozilla.org/en/docs/Web/API/Event/srcElement

closeLogOnClick(true) doesn't work in some browsers without this change