### PR TITLE
Fix #70 - Remove root element

### DIFF
--- a/src/js/alertify.js
+++ b/src/js/alertify.js
@@ -114,8 +114,8 @@
             close: function(elem, wait) {
 
                 if (this.closeLogOnClick) {
-                    elem.addEventListener("click", function(ev) {
-                        hideElement(ev.srcElement);
+                    elem.addEventListener("click", function() {
+                        hideElement(elem);
                     });
                 }
 


### PR DESCRIPTION
When user clicks on the element (or its children), alertify should remove the root element.