### PR TITLE
Cancel button should reject the promise

### DIFF
--- a/src/js/alertify.js
+++ b/src/js/alertify.js
@@ -265,10 +265,11 @@
                     }
                 }
 
-                function setupHandlers(resolve) {
+                function setupHandlers(resolve, reject) {
                     if ("function" !== typeof resolve) {
                         // promises are not available so resolve is a no-op
                         resolve = function () {};
+                        reject = function () {};
                     }
 
                     if (btnOK) {
@@ -304,7 +305,7 @@
                                 item.onCancel(ev);
                             }
 
-                            resolve({
+                            reject({
                                 buttonClicked: "cancel",
                                 event: ev
                             });


### PR DESCRIPTION
Why cancel button resolves the promise?

It should rejects the promise.

Note: this change breaks the backwards compatibility (fail function was in done function)