### PR TITLE
Add typings declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.11",
   "homepage": "https://alertifyjs.org/",
   "main": "dist/js/alertify.js",
+  "types": "alertify-js.d.ts",
   "author": "Fabien Doiron <fabien.doiron@gmail.com> (http://fabien-d.github.io/)",
   "contributors": [
     "Fabien Doiron <fabien.doiron@gmail.com> (http://fabien-d.github.io/)",


### PR DESCRIPTION
The typescript module resolver doesn't look for `alertify-js.d.ts`, only `alertify.d.ts` or `alertify.js.d.ts`. However, the filename can be specified with a `types` field in the `package.json` file (see http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

An alternative to this proposal would be to rename the typings file.